### PR TITLE
fix: relative URL in QR code is now absolute.

### DIFF
--- a/hagrid/reservations/views/administration.py
+++ b/hagrid/reservations/views/administration.py
@@ -67,7 +67,7 @@ class ReservationPDFDownloadView(LoginRequiredMixin, View):
                 timestamp=datetime.datetime.now().strftime("%m-%d_%H%M%S")
         )
 
-        data = generate_packing_pdf([reservation], filename, request, username=request.user.username)
+        data = generate_packing_pdf([reservation], filename, username=request.user.username)
 
         response = HttpResponse(data, content_type='application/pdf')
         response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)

--- a/hagrid/reservations/views/administration.py
+++ b/hagrid/reservations/views/administration.py
@@ -67,7 +67,7 @@ class ReservationPDFDownloadView(LoginRequiredMixin, View):
                 timestamp=datetime.datetime.now().strftime("%m-%d_%H%M%S")
         )
 
-        data = generate_packing_pdf([reservation], filename, username=request.user.username)
+        data = generate_packing_pdf([reservation], filename, request, username=request.user.username)
 
         response = HttpResponse(data, content_type='application/pdf')
         response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)


### PR DESCRIPTION
This fix uses the site header from the request to form an absolute URL.
Since this doesn't always work it would be best to require a hard coded
path somewhere. passing the request object all the way down to the
method rendering the QR code on the paper isn't really nice as well but
as long as there is now good other way and especially no setting
defining the server root this is the best way to go.