### PR TITLE
add: admin link to products_config_overview template

### DIFF
--- a/hagrid/products/templates/products_config_overview.html
+++ b/hagrid/products/templates/products_config_overview.html
@@ -16,7 +16,7 @@
           <a class="btn btn-secondary" href="{% url 'admin:products_product_changelist' %}">Products</a>
           <a class="btn btn-secondary" href="{% url 'admin:products_sizegroup_changelist' %}">Sizegroups</a>
           <a class="btn btn-secondary" href="{% url 'admin:products_size_changelist' %}">Sizes</a>
-          <a class="btn btn-primary" href="{% url 'admin:app_list' 'products' %}">All models</a>
+          <a class="btn btn-primary" href="{% url 'admin:index' %}">All models</a>
         </p>
 
         <h2>Item counting</h2>
@@ -47,6 +47,7 @@
         <p>
             <a class="btn btn-secondary" href="{% url 'variation_availability_event_list' %}">History of availabilities</a>
             <a class="btn btn-secondary" href="{% url 'reservationstatistics' %}">Item reservations</a>
+            <a class="btn btn-secondary" href="{% url 'operator_stats' %}">Sale Rate</a>
         </p>
     </div>
 </div>

--- a/hagrid/products/templates/products_config_overview.html
+++ b/hagrid/products/templates/products_config_overview.html
@@ -9,7 +9,7 @@
     <div class="col-sm-6">
         <h2>General config</h2>
         <p>
-          Some models are currently only configurable using Django Admin.
+          Some models are currently only configurable using <a href="{% url 'admin:index' %}">Django Admin</a>.
         </p>
         <p>
           <a class="btn btn-secondary" href="{% url 'admin:products_storesettings_changelist' %}1/change/">Store Settings</a>


### PR DESCRIPTION
It bugged me that there is no link to the admin interface in the operator view while that one is advertized there. Request for opinions if we should keep this.